### PR TITLE
Ava 115 prepare proof verification

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -105,13 +105,13 @@ fn kc_verify_proof_wrapper(
 	commitment: &[u8],
 ) -> bool {
 	let verification = kc_verify_proof(col, proof, commitment, total_rows, total_cols);
+	log::info!(
+		"Public params ({}): hash: {}",
+		verification.public_params_len,
+		verification.public_params_hash
+	);
 	match &verification.status {
 		Ok(()) => {
-			log::info!(
-				"Public params ({}): hash: {}",
-				verification.public_params_len,
-				verification.public_params_hash
-			);
 			log::info!("Verified cell ({}, {}) of block {}", row, col, block_num);
 		},
 		Err(verification_err) => {

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -126,7 +126,7 @@ fn kc_verify_proof_wrapper(
 			verification.status.is_ok()
 		},
 		Err(error) => {
-			log::info!(
+			log::error!(
 				"Failed for cell ({}, {}) of block {} with error {}",
 				row,
 				col,


### PR DESCRIPTION
This PR removes logging and possible panic code from kc_verify_proof function, to prepare it for migration to avail repo. Interface of method is change to preserve previous functionality as much as possible.