### PR TITLE
DHT CID mappings added

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -638,6 +638,8 @@ pub async fn make_client(
 	if !bootstrap_nodes.is_empty() {
 		ipfs.bootstrap(bootstrap_nodes).await?;
 	} else {
+		// If client is the first one on the network, wait for the second client ConnectionEstablished event to use it as bootstrap
+		// DHT requires boostrap to complete in order to be able to insert new records
 		let node = ipfs
 			.swarm_events()
 			.find_map(|event| {

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,7 @@ use std::{
 use async_std::stream::StreamExt;
 use ipfs_embed::{
 	identity::ed25519::{Keypair, SecretKey},
-	Cid, DefaultParams as IPFSDefaultParams, Ipfs, NetworkConfig, StorageConfig, PeerId, Multiaddr
+	Cid, DefaultParams as IPFSDefaultParams, Ipfs, Multiaddr, NetworkConfig, PeerId, StorageConfig,
 };
 use kate_recovery::com::{reconstruct_app_extrinsics, Cell, ExtendedMatrixDimensions};
 use libipld::Ipld;
@@ -651,7 +651,6 @@ pub async fn make_client(
 			.expect("Connection established");
 		ipfs.bootstrap(&[node]).await?;
 	}
-
 
 	Ok(ipfs)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,7 @@ use std::{
 use async_std::stream::StreamExt;
 use ipfs_embed::{
 	identity::ed25519::{Keypair, SecretKey},
-	Cid, DefaultParams as IPFSDefaultParams, Ipfs, NetworkConfig, StorageConfig,
+	Cid, DefaultParams as IPFSDefaultParams, Ipfs, NetworkConfig, StorageConfig, PeerId, Multiaddr
 };
 use kate_recovery::com::{reconstruct_app_extrinsics, Cell, ExtendedMatrixDimensions};
 use libipld::Ipld;
@@ -623,8 +623,9 @@ pub async fn make_client(
 	seed: u64,
 	port: u16,
 	path: &str,
+	bootstrap_nodes: &Vec<(PeerId, Multiaddr)>,
 ) -> anyhow::Result<Ipfs<IPFSDefaultParams>> {
-	let sweep_interval = Duration::from_secs(60);
+	let sweep_interval = Duration::from_secs(600);
 	let path_buf = std::path::PathBuf::from_str(path).unwrap();
 	let storage = StorageConfig::new(Some(path_buf), None, 10, sweep_interval);
 	let mut network = NetworkConfig::new(keypair(seed));
@@ -632,11 +633,25 @@ pub async fn make_client(
 
 	let ipfs = Ipfs::<IPFSDefaultParams>::new(ipfs_embed::Config { storage, network }).await?;
 
-	let mut stream = ipfs.listen_on(format!("/ip4/127.0.0.1/tcp/{}", port).parse()?)?;
-	if let ipfs_embed::ListenerEvent::NewListenAddr(_) = stream.next().await.unwrap() {
-		/* do nothing useful here, just ensure ipfs-node has
-		started listening on specified port */
+	_ = ipfs.listen_on(format!("/ip4/127.0.0.1/tcp/{}", port).parse()?)?;
+
+	if !bootstrap_nodes.is_empty() {
+		ipfs.bootstrap(bootstrap_nodes).await?;
+	} else {
+		let node = ipfs
+			.swarm_events()
+			.find_map(|event| {
+				if let ipfs_embed::Event::ConnectionEstablished(peer_id, connected_point) = event {
+					Some((peer_id, connected_point.get_remote_address().clone()))
+				} else {
+					None
+				}
+			})
+			.await
+			.expect("Connection established");
+		ipfs.bootstrap(&[node]).await?;
 	}
+
 
 	Ok(ipfs)
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -459,47 +459,51 @@ pub async fn ipfs_priority_get_cells(
 	rpc_url: &String,
 	block_num: u64,
 ) -> Result<()> {
-	println!("ipfs priority get started...");
 	// Try fetching the cells from IPFS first
 	for (_, req_cell_data) in cells.iter_mut().enumerate() {
 		let peers = ipfs.peers();
-		println!("number of peers: {}", peers.len());
+		log::info!("Number of known peers: {}", peers.len());
 		if peers.len() == 0 {
 			break;
 		}
-		// println!("list of connections: {:?}", ipfs.connections());
 		// TODO: paralelize fetching
 		// Skip cells that return error when fetching from IPFS
-		println!(
-			"Requesting from IPFS: CID: {}. Cell reference: {}.",
-			req_cell_data.cid(),
+		log::info!(
+			"Requesting from IPFS: cell reference: {}.",
 			req_cell_data.reference()
 		);
-		let mut block_cid: Cid = Cid::default();
-		if let Ok(record) = ipfs
-			.get_record(
-				Key::from(req_cell_data.reference().as_bytes().to_vec()),
-				ipfs_embed::Quorum::One,
-			)
+
+		let key = Key::from(req_cell_data.reference().as_bytes().to_vec());
+		let (block_cid, get_record_error): (Cid, _) = ipfs
+			.get_record(key, ipfs_embed::Quorum::One)
 			.await
-		{
-			block_cid = Cid::try_from(record[0].record.value.to_vec()).unwrap();
+			.map(|record| record[0].record.value.to_vec())
+			.and_then(|cid_value| Cid::try_from(cid_value).context("Invalid CID value"))
+			.map(|cid| (cid, None))
+			.unwrap_or_else(|error| (Cid::default(), Some(error)));
+
+		if let Some(error) = get_record_error {
+			log::error!(
+				"Cannot get CID from record: {}. Cell reference: {}",
+				error,
+				req_cell_data.reference()
+			);
+			continue;
 		}
 
 		if let Err(error) = ipfs.fetch(&block_cid, peers).await.and_then(|block| {
 			// IPFS block data contains cell proof
-			println!("BLOCK DATA: {:?}", block.data());
 			req_cell_data.proof = block.data().to_vec();
 			req_cell_data.data = req_cell_data.proof[48..].to_vec();
 			Ok(())
 		}) {
-			println!("ERROR FETCHING FROM IPFS: {}.", error);
+			log::error!(
+				"Error fetching data from IPFS: {}. Cell reference: {}",
+				error,
+				req_cell_data.reference()
+			);
+			continue;
 		}
-		// .context(format!(
-		// 	"{}:{}:{}",
-		// 	req_cell_data.block, req_cell_data.col, req_cell_data.row
-		// ));
-		// ipfs.sync(&req_cell_data.cid(), peers).await?;
 	}
 	let mut ipfs_cell_count = 0;
 	for cell in cells.iter_mut() {
@@ -507,7 +511,7 @@ pub async fn ipfs_priority_get_cells(
 			ipfs_cell_count += 1;
 		}
 	}
-	println!("Number of cells fetched from IPFS: {}", ipfs_cell_count);
+	log::info!("Number of cells fetched from IPFS: {}", ipfs_cell_count);
 
 	// Retrieve remaining cell proofs via RPC call to node
 	// TODO: handle case if 1 or more cells are unavailable via RPC (retry mechanism, generate new cells, etc)
@@ -525,7 +529,7 @@ pub async fn ipfs_priority_get_cells(
 		cell.data = cell.proof[48..].to_vec();
 	});
 
-	for (cell_index, cell_data) in cells.iter_mut().enumerate() {
+	for (_, cell_data) in cells.iter_mut().enumerate() {
 		// Skip cells with data retrieved from IPFS
 		if cell_data.data.len() != 0 {
 			continue;
@@ -536,7 +540,6 @@ pub async fn ipfs_priority_get_cells(
 				&& cell_data.col == remaining_cell.col
 				&& cell_data.row == remaining_cell.row
 			{
-				// println!("remaining cell data len: {}", remaining_cell.data.len());
 				cell_data.data = remaining_cell.data.clone();
 				cell_data.proof = remaining_cell.proof.clone();
 			}
@@ -550,6 +553,7 @@ pub async fn ipfs_priority_get_cells(
 mod tests {
 	extern crate rand;
 
+	use ipfs_embed::{Multiaddr, PeerId};
 	use proptest::{collection, prelude::*};
 	use rand::prelude::random;
 	use test_case::test_case;
@@ -662,53 +666,5 @@ mod tests {
 		// 256 bytes of random data
 		let msg = random_data(256);
 		assert_eq!(decode_block_cid_ask_message(msg), None);
-	}
-
-	#[tokio::test]
-	async fn test_data_matrix_coding_decoding_flow() {
-		let ipfs = make_client(1, 10000, "test").await.unwrap();
-		let block: u64 = 1 << 63;
-		let row_c = 4;
-		let col_c = 4;
-		let cells: Vec<Option<Vec<u8>>> = vec![
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-			Some(random_data(80)),
-		];
-		let arced = Arc::new(cells.clone());
-		let data_matrix = construct_matrix(block, row_c, col_c, arced).unwrap();
-		let prev_cid: Cid = {
-			let flag = Ipld::Bool(true);
-			*IpldBlock::encode(IpldCodec::DagCbor, Code::Blake3_256, &flag)
-				.unwrap()
-				.cid()
-		};
-		let pin = &mut ipfs.create_temp_pin().unwrap();
-		let root_cid = push_matrix(data_matrix, Some(prev_cid), &ipfs, pin)
-			.await
-			.unwrap();
-
-		let result = get_matrix(&ipfs, Some(root_cid)).await.unwrap();
-
-		let mut cells_iter = cells.iter();
-
-		for col in result {
-			for cell in col {
-				assert_eq!(cells_iter.next().unwrap().as_ref().unwrap(), &cell.unwrap());
-			}
-		}
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ pub async fn do_main() -> Result<()> {
 					}
 					let commitment = header.extrinsics_root.commitment.clone();
 					let mut cells = rpc::generate_random_cells(max_rows, max_cols, num);
-					println!(
+					log::info!(
 						"Random cells generated: {} from block: {}",
 						cells.len(),
 						num
@@ -213,7 +213,16 @@ pub async fn do_main() -> Result<()> {
 
 					let ipfs_2 = ipfs.clone();
 					// TODO: error handling
-					data::ipfs_priority_get_cells(&mut cells, &ipfs_2, &rpc_url, num).await?;
+					if let Err(error) =
+						data::ipfs_priority_get_cells(&mut cells, &ipfs_2, &rpc_url, num).await
+					{
+						log::error!(
+							"Error retrieveing cells for verification for block {}: {}",
+							num,
+							error
+						);
+						continue;
+					}
 
 					let count = proof::verify_proof(
 						num,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use futures_util::{SinkExt, StreamExt};
-use ipfs_embed::{Multiaddr, PeerId, Record, Key};
+use ipfs_embed::{Key, Multiaddr, PeerId, Record};
 // use kate_recovery::com::{
 // 	app_specific_column_cells, reconstruct_app_extrinsics, Cell, ExtendedMatrixDimensions,
 // };
@@ -126,7 +126,13 @@ pub async fn do_main() -> Result<()> {
 		.map(|(a, b)| (PeerId::from_str(a).expect("Valid peer id"), b.clone()))
 		.collect::<Vec<(PeerId, Multiaddr)>>();
 
-	let ipfs = client::make_client(cfg.ipfs_seed, cfg.ipfs_port, &cfg.ipfs_path, bootstrap_nodes).await?;
+	let ipfs = client::make_client(
+		cfg.ipfs_seed,
+		cfg.ipfs_port,
+		&cfg.ipfs_path,
+		bootstrap_nodes,
+	)
+	.await?;
 
 	#[cfg(feature = "logs")]
 	tokio::task::spawn(client::log_events(ipfs.clone()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,16 +5,16 @@ extern crate structopt;
 use std::{
 	str::FromStr,
 	sync::{mpsc::sync_channel, Arc},
-	thread,
+	thread, time,
 	time::SystemTime,
 };
 
 use anyhow::{Context, Result};
 use futures_util::{SinkExt, StreamExt};
-use ipfs_embed::{Multiaddr, PeerId};
-use kate_recovery::com::{
-	app_specific_column_cells, reconstruct_app_extrinsics, Cell, ExtendedMatrixDimensions,
-};
+use ipfs_embed::{Multiaddr, PeerId, Record, Key};
+// use kate_recovery::com::{
+// 	app_specific_column_cells, reconstruct_app_extrinsics, Cell, ExtendedMatrixDimensions,
+// };
 use rocksdb::{ColumnFamilyDescriptor, Options, DB};
 use simple_logger::SimpleLogger;
 use structopt::StructOpt;
@@ -120,7 +120,13 @@ pub async fn do_main() -> Result<()> {
 	let (self_info_tx, self_info_rx) = sync_channel::<(PeerId, Multiaddr)>(1);
 	let (destroy_tx, destroy_rx) = sync_channel::<bool>(1);
 
-	let ipfs = client::make_client(cfg.ipfs_seed, cfg.ipfs_port, &cfg.ipfs_path).await?;
+	let bootstrap_nodes = &cfg
+		.bootstraps
+		.iter()
+		.map(|(a, b)| (PeerId::from_str(a).expect("Valid peer id"), b.clone()))
+		.collect::<Vec<(PeerId, Multiaddr)>>();
+
+	let ipfs = client::make_client(cfg.ipfs_seed, cfg.ipfs_port, &cfg.ipfs_path, bootstrap_nodes).await?;
 
 	#[cfg(feature = "logs")]
 	tokio::task::spawn(client::log_events(ipfs.clone()));
@@ -128,27 +134,14 @@ pub async fn do_main() -> Result<()> {
 	// inform invoker about self
 	self_info_tx.send((ipfs.local_peer_id(), ipfs.listeners()[0].clone()))?;
 
-	// bootstrap client with non-empty set of
-	// application clients
-	if !cfg.bootstraps.is_empty() {
-		ipfs.bootstrap(
-			&cfg.bootstraps
-				.clone()
-				.into_iter()
-				.map(|(a, b)| (PeerId::from_str(&a).unwrap(), b))
-				.collect::<Vec<(_, _)>>()[..],
-		)
-		.await?;
-	}
-
 	// this one will spawn one thread for running ipfs client, while managing data discovery
 	// and reconstruction
 	let db_1 = db.clone();
 	let cfg_ = cfg.clone();
 	let ipfs_ = ipfs.clone();
-	thread::spawn(move || {
-		client::run_client(cfg_, db_1, block_rx, destroy_rx, cell_query_rx, ipfs_).unwrap();
-	});
+	// thread::spawn(move || {
+	// 	client::run_client(cfg_, db_1, block_rx, destroy_rx, cell_query_rx, ipfs_).unwrap();
+	// });
 	if let Ok((peer_id, addrs)) = self_info_rx.recv() {
 		log::info!("IPFS backed application client: {}\t{:?}", peer_id, addrs);
 	};
@@ -159,9 +152,12 @@ pub async fn do_main() -> Result<()> {
 	let latest_block = block_header.number;
 	let rpc_ = rpc_url.clone();
 	let db_2 = db.clone();
+	let ipfs2_ = ipfs.clone();
 
+	// TODO: implement proper sync between bootstrap completion and starting the sync function
+	thread::sleep(time::Duration::from_secs(3));
 	tokio::spawn(async move {
-		sync::sync_block_headers(rpc_.clone(), 0, latest_block, db_2).await;
+		sync::sync_block_headers(rpc_.clone(), 0, latest_block, db_2, ipfs2_).await;
 	});
 
 	const BODY: &str = r#"{"id":1, "jsonrpc":"2.0", "method": "chain_subscribeFinalizedHeads"}"#;
@@ -202,10 +198,17 @@ pub async fn do_main() -> Result<()> {
 						log::error!("chunk size less than 3");
 					}
 					let commitment = header.extrinsics_root.commitment.clone();
-					let kate_cells = rpc::generate_random_cells(max_rows, max_cols, num);
-					//hyper request for getting the kate query request
-					let cells = rpc::get_kate_proof(&rpc_url, num, kate_cells).await?;
-					//hyper request for verifying the proof
+					let mut cells = rpc::generate_random_cells(max_rows, max_cols, num);
+					println!(
+						"Random cells generated: {} from block: {}",
+						cells.len(),
+						num
+					);
+
+					let ipfs_2 = ipfs.clone();
+					// TODO: error handling
+					data::ipfs_priority_get_cells(&mut cells, &ipfs_2, &rpc_url, num).await?;
+
 					let count = proof::verify_proof(
 						num,
 						max_rows,
@@ -227,130 +230,7 @@ pub async fn do_main() -> Result<()> {
 						.context("failed to write confidence factor")?;
 
 					let conf = calculate_confidence(count);
-					let app_index = header.app_data_lookup.index.clone();
-
-					if cfg.app_id.is_none() {
-						continue;
-					}
-
-					/*note:
-					The following is the part when the user have already subscribed
-					to an appID and now its verifying every cell that contains the data
-					*/
-					//@TODO : Major optimization needed here
-					let dimension = ExtendedMatrixDimensions {
-						rows: max_rows as usize,
-						cols: max_cols as usize,
-					};
-
-					let app_id = cfg.app_id.unwrap_or_default();
-
-					if conf >= cfg.confidence
-						&& ((!app_index.is_empty() && app_id > 0) || app_id == 0)
-					{
-						let layout =
-							client::layout_from_index(&app_index, header.app_data_lookup.size);
-
-						match app_specific_column_cells(&layout, &dimension, app_id as u32) {
-							None => {
-								log::info!("No app specific cells for app {}", app_id);
-								continue;
-							},
-							Some(recon_cells) => {
-								// Since extended rows count (max_rows) is divisible by 2,
-								// take first half of cells of a each column
-								let recon_cells_half = recon_cells
-									.into_iter()
-									.filter(|cell| cell.row <= (max_rows / 2 - 1))
-									.collect::<Vec<_>>();
-
-								let query_cells: Vec<types::Cell> =
-									rpc::from_kate_cells(num, &recon_cells_half);
-
-								let mut verified = true;
-								let mut verified_cells = vec![];
-								for cell in query_cells.chunks(30) {
-									let cells =
-										rpc::get_kate_proof(&rpc_url, num, (*cell).to_vec())
-											.await?;
-									let verified_cells_count = proof::verify_proof(
-										num,
-										max_rows,
-										max_cols,
-										cells.clone(),
-										commitment.clone(),
-									);
-									if (verified_cells_count as usize) < cells.len() {
-										log::info!(
-											"Verified {} of {} cells, skipping reconstruction",
-											verified_cells_count,
-											cells.len()
-										);
-										verified = false;
-										break;
-									} else {
-										log::info!("Verified {} cells", verified_cells_count);
-									}
-									verified_cells.extend(cells);
-								}
-								if verified {
-									let reconstruction_cells = verified_cells
-										.iter()
-										.map(|cell| Cell {
-											col: cell.col,
-											row: cell.row,
-											data: cell.proof[48..].to_vec(),
-										})
-										.collect::<Vec<_>>();
-
-									let layout = client::layout_from_index(
-										header.app_data_lookup.index.as_slice(),
-										header.app_data_lookup.size,
-									);
-
-									let dimension = ExtendedMatrixDimensions {
-										rows: max_rows as usize,
-										cols: max_cols as usize,
-									};
-
-									match reconstruct_app_extrinsics(
-										&layout,
-										&dimension,
-										reconstruction_cells,
-										None,
-									) {
-										Ok(xts) => {
-											for e in xts {
-												let data_hex_string = e
-													.1
-													.iter()
-													.map(|e| {
-														e.iter().fold(
-															String::new(),
-															|mut acc, e| {
-																acc.push_str(
-																	format!("{:02x}", e).as_str(),
-																);
-																acc
-															},
-														)
-													})
-													.collect::<Vec<_>>();
-												log::debug!(
-													"Reconstructed extrinsic: app_id={}, data={:?}",
-													e.0,
-													data_hex_string
-												);
-											}
-										},
-										Err(error) => {
-											log::error!("Reconstruction error: {}", error)
-										},
-									}
-								}
-							},
-						}
-					}
+					log::info!("Confidence factor for block {}: {}", num, conf);
 
 					// push latest mined block's header into column family specified
 					// for keeping block headers, to be used
@@ -369,28 +249,45 @@ pub async fn do_main() -> Result<()> {
 
 					// Push the randomly selected cells to IPFS
 					for cell in cells {
-						let reference = cell.reference();
-						println!("cell reference: {:?}, hash: {:?}", reference, &cell.hash());
-
-						if let Err(error) = ipfs.insert(cell.to_ipfs_block()) {
+						if let Err(error) = ipfs.insert(cell.clone().to_ipfs_block()) {
 							log::info!(
 								"Error pushing cell to IPFS: {}. Cell reference: {}",
 								error,
-								reference
+								cell.reference()
+							);
+						}
+						// Add generated CID to DHT
+						if let Err(error) = ipfs
+							.put_record(
+								Record::new(
+									cell.reference().as_bytes().to_vec(),
+									cell.cid().to_bytes(),
+								),
+								ipfs_embed::Quorum::One,
+							)
+							.await
+						{
+							log::info!(
+								"Error inserting new record to DHT: {}. Cell reference: {}",
+								error,
+								cell.reference()
 							);
 						}
 					}
+					if let Err(error) = ipfs.flush().await {
+						println!("ERRROR FLUSHING: {}", error)
+					};
 
 					// notify ipfs-based application client
 					// that newly mined block has been received
-					block_tx
-						.send(types::ClientMsg {
-							num,
-							max_rows,
-							max_cols,
-							header,
-						})
-						.context("failed to send block to client")?;
+					// block_tx
+					// 	.send(types::ClientMsg {
+					// 		num,
+					// 		max_rows,
+					// 		max_cols,
+					// 		header,
+					// 	})
+					// 	.context("failed to send block to client")?;
 				},
 				Err(error) => log::info!("Misconstructed Header: {:?}", error),
 			}

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,7 +281,7 @@ pub async fn do_main() -> Result<()> {
 						}
 					}
 					if let Err(error) = ipfs.flush().await {
-						println!("ERRROR FLUSHING: {}", error)
+						log::info!("Error flushin data do disk: {}", error,);
 					};
 
 					// notify ipfs-based application client

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -17,18 +17,18 @@ fn kc_verify_proof_wrapper(
 ) -> bool {
 	match kate_proof::kc_verify_proof(col, proof, commitment, total_rows, total_cols) {
 		Ok(verification) => {
-			log::info!(
+			log::trace!(
 				"Public params ({}): hash: {}",
 				verification.public_params_len,
 				verification.public_params_hash
 			);
 			match &verification.status {
 				Ok(()) => {
-					log::info!("Verified cell ({}, {}) of block {}", row, col, block_num);
+					log::trace!("Verified cell ({}, {}) of block {}", row, col, block_num);
 				},
 				Err(verification_err) => {
-					log::info!("Verification error: {:?}", verification_err);
-					log::info!("Failed for cell ({}, {}) of block {}", row, col, block_num);
+					log::error!("Verification error: {:?}", verification_err);
+					log::error!("Failed for cell ({}, {}) of block {}", row, col, block_num);
 				},
 			}
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -300,14 +300,15 @@ impl Cell {
 	/// Cell refrence in format `block_number:column_number:row_number`
 	pub fn reference(&self) -> String { format!("{}:{}:{}", self.block, self.col, self.row) }
 
-	pub fn hash(&self) -> Multihash { Code::Sha3_256.digest(self.reference().as_bytes()) }
+	pub fn hash(&self) -> Multihash { Code::Sha3_256.digest(&self.proof) }
 
-	pub fn cid(&self) -> Cid { Cid::new_v1(IpldCodec::DagCbor.into(), self.hash()) }
+	pub fn cid(&self) -> Cid { Cid::new_v1(IpldCodec::Raw.into(), self.hash()) }
 
 	// Block data isn't encoded
 	// TODO: optimization - multiple cells inside a single block (per appID)
+	// TODO: error handling
 	pub fn to_ipfs_block(self) -> IpfsBlock<DefaultParams> {
-		IpfsBlock::<DefaultParams>::new_unchecked(self.cid(), self.data)
+		IpfsBlock::<DefaultParams>::new(self.cid(), self.proof).unwrap()
 	}
 }
 


### PR DESCRIPTION
- CIDs are generated now from `proof` hashes
- added DHT CID mapping in the following format: `cell_reference:CID`
- modified sync and sampling logic to prioritize IPFS over RPC
- added timeout before sync start to allow client to be bootstrapped
- increase garbage collector interval to 10 minutes
- removed app reconstruction from LC (to be added to app client at a later point)
- added a bootstrap workaround for the first LC in the network - wait for the immediate second one to use it as a boostrap

TODOs:

- [ ] - replace thread timeout with more adequate solution
- [ ] - tweak the `store` and `network` parameters
- [x] - remove printlns
- [x] - introduce proper error handling 
- [x] - remove commented code

NOTES:
- app client spawning and channel loop temporarily disabled