### PR TITLE
Fix multiplication with overflow issue on matrix of maximum size.

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -21,7 +21,8 @@ fn construct_cell(
 	row_count: u16,
 	cells: Arc<Vec<Option<Vec<u8>>>>,
 ) -> Result<BaseCell, String> {
-	cells[(col * row_count + row) as usize]
+	let cell_index = (col as usize) * (row_count as usize) + (row as usize);
+	cells[cell_index]
 		.as_ref()
 		.ok_or_else(|| "failed to construct cell due to unavailability of data".to_owned())
 		.and_then(|cell| {


### PR DESCRIPTION
By returning maximum block dimensions instead of calculating next power of two, and padding block to maximum size with random numbers, I was able to cause panics on multiplication overflow in three cases. Cases in get_cells are not reproduced due to time needed to build 130K proofs on avail (it seems that more than 1 hour is needed).