### PR TITLE
Ava 275

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -47,22 +47,10 @@ pub async fn init_ipfs(
 	let _ = ipfs.listen_on(format!("/ip4/127.0.0.1/tcp/{}", port).parse()?)?;
 
 	if !bootstrap_nodes.is_empty() {
+		log::info!("Bootstraping the DHT with bootstrap nodes...");
 		ipfs.bootstrap(bootstrap_nodes).await?;
 	} else {
-		// If client is the first one on the network, wait for the second client ConnectionEstablished event to use it as bootstrap
-		// DHT requires boostrap to complete in order to be able to insert new records
-		let node = ipfs
-			.swarm_events()
-			.find_map(|event| {
-				if let ipfs_embed::Event::ConnectionEstablished(peer_id, connected_point) = event {
-					Some((peer_id, connected_point.get_remote_address().clone()))
-				} else {
-					None
-				}
-			})
-			.await
-			.context("Connection is not established")?;
-		ipfs.bootstrap(&[node]).await?;
+		log::info!("No bootstrap nodes, DHT will be available after first peer connects");
 	}
 
 	Ok(ipfs)

--- a/src/data.rs
+++ b/src/data.rs
@@ -53,6 +53,14 @@ pub async fn init_ipfs(
 		log::info!("No bootstrap nodes, DHT will be available after first peer connects");
 	}
 
+	let peer_id = ipfs.local_peer_id();
+	// In rare cases there are no listeners, performing safe get
+	if let Some(listener) = ipfs.listeners().get(0) {
+		log::info!("IPFS backed application client: {peer_id}\t{listener:?}");
+	} else {
+		log::info!("IPFS backed application client: {peer_id}");
+	}
+
 	Ok(ipfs)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,6 @@ pub async fn do_main() -> Result<()> {
 	// communication channels being established for talking to
 	// ipfs backed application client
 	let (block_tx, block_rx) = sync_channel::<types::ClientMsg>(1 << 7);
-	let (self_info_tx, self_info_rx) = sync_channel::<(PeerId, Multiaddr)>(1);
 
 	let bootstrap_nodes = &cfg
 		.bootstraps
@@ -140,13 +139,6 @@ pub async fn do_main() -> Result<()> {
 	.context("Failed to init IPFS client")?;
 
 	tokio::task::spawn(data::log_ipfs_events(ipfs.clone()));
-
-	// inform invoker about self
-	self_info_tx.send((ipfs.local_peer_id(), ipfs.listeners()[0].clone()))?;
-
-	if let Ok((peer_id, addrs)) = self_info_rx.recv() {
-		log::info!("IPFS backed application client: {peer_id}\t{addrs:?}");
-	};
 
 	let pp = kate_proof::testnet::public_params(1024);
 	let raw_pp = pp.to_raw_var_bytes();


### PR DESCRIPTION
It seems that issue was either fixed with update to IPFS 0.23.0, or it was unclear what behavior should be in cases of failed DHT put operations. In any case, after removing explicit wait for second peer, observed behavior is:

- First node cannot write to DHT before second node connects
- When second node connects, both can write to DHT
- When second node disconnects. first node cannot write to DHT again
- Failed DHT entries are "lost", there are no retries (which makes sense since there is no network)
- First node never finds anything from other (4) peers (probably because of predictable behavior on same hardware)
- When first node disconnects other nodes continue to function properly
- Restarting first node should include adding bootstrap node to avoid cases when first node is deleted from other DHTs

Another issue is that light client crashes in rare cases after IPFS initialization due to empty IPFS listeners, probably caused by some concurrency bug (e.g. listeners are populated in some thread). This is fixed by using safe get and logging only peer ID if listener is not available