### PR TITLE
Set json logs format in configuration file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5068,11 +5068,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ scale-info = { version = "2.0.0", features = ["bit-vec"] }
 hex = "0.4"
 warp = "0.3.2"
 tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.15" }
+tracing-subscriber = { version = "0.3.15", features = ["json"] }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/src/types.rs
+++ b/src/types.rs
@@ -359,6 +359,7 @@ pub struct RuntimeConfig {
 	pub bootstraps: Vec<(String, Multiaddr)>,
 	pub avail_path: String,
 	pub log_level: String,
+	pub log_format_json: Option<bool>,
 	pub max_parallel_fetch_tasks: usize,
 }
 
@@ -378,6 +379,7 @@ impl Default for RuntimeConfig {
 			bootstraps: Vec::new(),
 			avail_path: format!("avail_light_client_{}", 1),
 			log_level: "INFO".to_owned(),
+			log_format_json: Some(false),
 			max_parallel_fetch_tasks: 8,
 		}
 	}


### PR DESCRIPTION
This PR makes configuring JSON format of logs optional, with default of using full format (suitable for development).