### PR TITLE
add Prometheus server to light client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "num",
  "num_cpus",
  "parity-scale-codec",
+ "prometheus",
  "proptest",
  "rand 0.8.5",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ hex = "0.4"
 warp = "0.3.2"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.15", features = ["json"] }
+prometheus = { version = "0.13.0", default-features = false }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -7,9 +7,7 @@ use anyhow::{Context, Result};
 use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
 use futures_util::{SinkExt, StreamExt};
 use ipfs_embed::{DefaultParams, Ipfs};
-use prometheus::{
-	Registry,
-};
+use prometheus::Registry;
 use rocksdb::DB;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tracing::{error, info};

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -42,7 +42,7 @@ pub async fn run(
 	)?);
 	registry
 		.register(block_counter.clone())
-		.expect("Registers block counter metric");
+		.context("Failed to register block counter metric")?;
 
 	while let Some(z) = rpc::check_connection(&urls).await {
 		let (mut write, mut read) = z.split();

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -8,7 +8,6 @@ use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
 use futures_util::{SinkExt, StreamExt};
 use ipfs_embed::{DefaultParams, Ipfs};
 use prometheus::{
-	core::{AtomicF64, GenericCounter},
 	Registry,
 };
 use rocksdb::DB;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ pub async fn do_main() -> Result<()> {
 		registry.clone(),
 	));
 
-	log::info!("Using {:?}", cfg);
+	info!("Using config: {:?}", cfg);
 
 	let db = init_db(&cfg.avail_path).context("Failed to init DB")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,8 @@ pub async fn do_main() -> Result<()> {
 		warn!("Using default log level: {}", error);
 	}
 
+	info!("Using config: {:?}", cfg);
+
 	// Spawn Prometheus server
 	let registry = Registry::default();
 
@@ -123,8 +125,6 @@ pub async fn do_main() -> Result<()> {
 		SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9520),
 		registry.clone(),
 	));
-
-	info!("Using config: {:?}", cfg);
 
 	let db = init_db(&cfg.avail_path).context("Failed to init DB")?;
 

--- a/src/prometheus_handler.rs
+++ b/src/prometheus_handler.rs
@@ -16,16 +16,8 @@ pub use prometheus::{
 	exponential_buckets, Error as PrometheusError, Histogram, HistogramOpts, HistogramVec, Opts,
 	Registry,
 };
-use prometheus::{core::Collector, Encoder, TextEncoder};
+use prometheus::{Encoder, TextEncoder};
 use tracing::info;
-
-pub fn register<T: Clone + Collector + 'static>(
-	metric: T,
-	registry: &Registry,
-) -> Result<T, PrometheusError> {
-	registry.register(Box::new(metric.clone()))?;
-	Ok(metric)
-}
 
 async fn request_metrics(req: Request<Body>, registry: Registry) -> Result<Response<Body>> {
 	if req.uri().path() == "/metrics" {

--- a/src/prometheus_handler.rs
+++ b/src/prometheus_handler.rs
@@ -1,0 +1,78 @@
+use std::net::SocketAddr;
+
+use anyhow::{Context, Error, Result};
+use hyper::{
+	http::StatusCode,
+	server::Server,
+	service::{make_service_fn, service_fn},
+	Body, Request, Response,
+};
+pub use prometheus::{
+	self,
+	core::{
+		AtomicF64 as F64, AtomicI64 as I64, AtomicU64 as U64, GenericCounter as Counter,
+		GenericCounterVec as CounterVec, GenericGauge as Gauge, GenericGaugeVec as GaugeVec,
+	},
+	exponential_buckets, Error as PrometheusError, Histogram, HistogramOpts, HistogramVec, Opts,
+	Registry,
+};
+use prometheus::{core::Collector, Encoder, TextEncoder};
+
+pub fn register<T: Clone + Collector + 'static>(
+	metric: T,
+	registry: &Registry,
+) -> Result<T, PrometheusError> {
+	registry.register(Box::new(metric.clone()))?;
+	Ok(metric)
+}
+
+async fn request_metrics(req: Request<Body>, registry: Registry) -> Result<Response<Body>> {
+	if req.uri().path() == "/metrics" {
+		let metric_families = registry.gather();
+		let mut buffer = vec![];
+		let encoder = TextEncoder::new();
+		encoder
+			.encode(&metric_families, &mut buffer)
+			.context("Metric encoding error");
+
+		Response::builder()
+			.status(StatusCode::OK)
+			.header("Content-Type", encoder.format_type())
+			.body(Body::from(buffer))
+			.map_err(|e| anyhow::anyhow!("Error creating body from buffer: {}", e))
+	} else {
+		Response::builder()
+			.status(StatusCode::NOT_FOUND)
+			.body(Body::from("Not found."))
+			.map_err(|_| anyhow::anyhow!("Endpoint not found"))
+	}
+}
+
+/// Init prometheus using the given listener.
+pub async fn init_prometheus_with_listener(
+	prometheus_addr: SocketAddr,
+	registry: Registry,
+) -> Result<(), Error> {
+	let listener = tokio::net::TcpListener::bind(&prometheus_addr)
+		.await
+		.map_err(|_| anyhow::anyhow!("Port already in use: {}", prometheus_addr))?;
+
+	let listener = hyper::server::conn::AddrIncoming::from_listener(listener)?;
+	log::info!("Prometheus exporter started at {}", listener.local_addr());
+
+	let service = make_service_fn(move |_| {
+		let registry = registry.clone();
+
+		async move {
+			Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
+				request_metrics(req, registry.clone())
+			}))
+		}
+	});
+
+	let server = Server::builder(listener).serve(service);
+
+	let result = server.await.map_err(Into::into);
+
+	result
+}

--- a/src/prometheus_handler.rs
+++ b/src/prometheus_handler.rs
@@ -17,7 +17,7 @@ pub use prometheus::{
 	Registry,
 };
 use prometheus::{core::Collector, Encoder, TextEncoder};
-use tracing::{info};
+use tracing::info;
 
 pub fn register<T: Clone + Collector + 'static>(
 	metric: T,

--- a/src/prometheus_handler.rs
+++ b/src/prometheus_handler.rs
@@ -17,6 +17,7 @@ pub use prometheus::{
 	Registry,
 };
 use prometheus::{core::Collector, Encoder, TextEncoder};
+use tracing::{info};
 
 pub fn register<T: Clone + Collector + 'static>(
 	metric: T,
@@ -33,7 +34,7 @@ async fn request_metrics(req: Request<Body>, registry: Registry) -> Result<Respo
 		let encoder = TextEncoder::new();
 		encoder
 			.encode(&metric_families, &mut buffer)
-			.context("Metric encoding error");
+			.context("Metric encoding error")?;
 
 		Response::builder()
 			.status(StatusCode::OK)
@@ -58,7 +59,7 @@ pub async fn init_prometheus_with_listener(
 		.map_err(|_| anyhow::anyhow!("Port already in use: {}", prometheus_addr))?;
 
 	let listener = hyper::server::conn::AddrIncoming::from_listener(listener)?;
-	log::info!("Prometheus exporter started at {}", listener.local_addr());
+	info!("Prometheus exporter started at {}", listener.local_addr());
 
 	let service = make_service_fn(move |_| {
 		let registry = registry.clone();


### PR DESCRIPTION
- added Prometheus exporter (hardcoded port 9520)
- added a single test counter for block number

TODO:
- parametarize or randomize local Prometheus server port
- add more metrics 