### PR TITLE
Add disable_rpc configuration parameter.

### DIFF
--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -20,7 +20,7 @@ use crate::{
 		fetch_cells_from_dht, insert_into_dht, store_block_header_in_db, store_confidence_in_db,
 	},
 	http::calculate_confidence,
-	proof, rpc, prometheus_handler, 
+	prometheus_handler, proof, rpc,
 	types::{self, ClientMsg, LightClientConfig, QueryResult},
 };
 

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -1,6 +1,9 @@
 use std::{
-	sync::{mpsc::SyncSender, Arc},
-	time::SystemTime,
+	sync::{
+		mpsc::{sync_channel, SyncSender},
+		Arc,
+	},
+	time::{Duration, Instant, SystemTime},
 };
 
 use anyhow::{Context, Result};
@@ -17,8 +20,8 @@ use crate::{
 		fetch_cells_from_dht, insert_into_dht, store_block_header_in_db, store_confidence_in_db,
 	},
 	http::calculate_confidence,
-	proof, rpc, prometheus_handler,
-	types::{self, ClientMsg, LightClientConfig},
+	proof, rpc, prometheus_handler, 
+	types::{self, ClientMsg, LightClientConfig, QueryResult},
 };
 
 struct LCMetrics {
@@ -78,125 +81,184 @@ pub async fn run(
 
 		info!("Connected to Substrate Node");
 
-		while let Some(message) = read.next().await {
-			let data = message?.into_data();
-			match serde_json::from_slice(&data) {
-				Ok(types::Response { params, .. }) => {
-					metrics.block_counter.inc();
-					let header = &params.header;
+		struct BlockAvailableMsg {
+			params: QueryResult,
+			received_at: Instant,
+		}
 
-					// now this is in `u64`
-					let block_number = header.number;
+		let (message_tx, message_rx) = sync_channel::<BlockAvailableMsg>(1 << 7);
 
-					let begin = SystemTime::now();
-
-					// TODO: Setting max rows * 2 to match extended matrix dimensions
-					let max_rows = header.extrinsics_root.rows * 2;
-					let max_cols = header.extrinsics_root.cols;
-					if max_cols < 3 {
-						error!(block_number, "chunk size less than 3");
-					}
-					let commitment = header.extrinsics_root.commitment.clone();
-
-					let cell_count = rpc::cell_count_for_confidence(cfg.confidence);
-					let positions = rpc::generate_random_cells(max_rows, max_cols, cell_count);
-					info!(block_number, "Random cells generated: {}", positions.len());
-
-					let (ipfs_fetched, unfetched) = fetch_cells_from_dht(
-						&ipfs,
-						block_number,
-						&positions,
-						cfg.max_parallel_fetch_tasks,
-					)
-					.await
-					.context("Failed to fetch cells from DHT")?;
-
-					info!(
-						block_number,
-						"Number of cells fetched from DHT: {}",
-						ipfs_fetched.len()
-					);
-					metrics.dht_fetched.set(ipfs_fetched.len() as f64);
-
-					let rpc_fetched = if cfg.disable_rpc {
-						vec![]
-					} else {
-						rpc::get_kate_proof(&rpc_url, block_number, unfetched)
-							.await
-							.context("Failed to fetch cells from node RPC")?
-					};
-
-					info!(
-						block_number,
-						"Number of cells fetched from RPC: {}",
-						rpc_fetched.len()
-					);
-
-					metrics.node_rpc_fetched.set(rpc_fetched.len() as f64);
-
-					let mut cells = vec![];
-					cells.extend(ipfs_fetched);
-					cells.extend(rpc_fetched.clone());
-
-					if positions.len() > cells.len() {
-						error!(
-							block_number,
-							"Failed to fetch {} cells",
-							positions.len() - cells.len()
-						);
-						continue;
-					}
-
-					let count = proof::verify_proof(
-						block_number,
-						max_rows,
-						max_cols,
-						&cells,
-						commitment.clone(),
-						pp.clone(),
-					);
-					info!(
-						block_number,
-						"Completed {count} verification rounds in \t{:?}",
-						begin.elapsed()?
-					);
-
-					// write confidence factor into on-disk database
-					store_confidence_in_db(db.clone(), block_number, count as u32)
-						.context("Failed to store confidence in DB")?;
-
-					let conf = calculate_confidence(count as u32);
-					info!(block_number, "Confidence factor: {}", conf);
-					metrics.block_confidence.set(conf);
-
-					// push latest mined block's header into column family specified
-					// for keeping block headers, to be used
-					// later for verifying IPFS stored data
-					//
-					// @note this same data store is also written to in
-					// another competing thread, which syncs all block headers
-					// in range [0, LATEST], where LATEST = latest block number
-					// when this process started
-					store_block_header_in_db(db.clone(), block_number, header)
-						.context("Failed to store block header in DB")?;
-
-					insert_into_dht(
-						&ipfs,
-						block_number,
-						rpc_fetched,
-						cfg.max_parallel_fetch_tasks,
-					)
-					.await;
-					info!(block_number, "Cells inserted into DHT");
-
-					// notify ipfs-based application client
-					// that newly mined block has been received
-					block_tx
-						.send(types::ClientMsg::from(params.header))
-						.context("Failed to send block message")?;
-				},
-				Err(error) => info!("Misconstructed Header: {:?}", error),
+		tokio::spawn(async move {
+			while let Some(message) = read.next().await {
+				if let Err(error) = message
+					.context("Failed to read web socket message")
+					.map(|data| data.into_data())
+					.and_then(|data| serde_json::from_slice(&data).context("Fail to decode data"))
+					.map(|types::Response { params, .. }| (params.header.number, params))
+					.map(|(block_number, params)| {
+						(block_number, BlockAvailableMsg {
+							params,
+							received_at: Instant::now(),
+						})
+					})
+					.and_then(|(block_number, message)| {
+						info!(block_number, "Received finalized block header");
+						message_tx.send(message).context("Cannot send  message")
+					}) {
+					error!("Fail to process finalized block header: {error}");
+				}
 			}
+		});
+
+		for message in message_rx {
+			if let Some(seconds) = cfg.block_processing_delay {
+				let sleep_time = Duration::from_secs(seconds.into());
+				let elapsed = message.received_at.elapsed();
+				if sleep_time > elapsed {
+					tokio::time::sleep(sleep_time - elapsed).await;
+				};
+			}
+
+			metrics.block_counter.inc();
+			let header = &message.params.header;
+
+			// now this is in `u64`
+			let block_number = header.number;
+			info!(
+				block_number,
+				"Processing finalized block (delayed for {} seconds)",
+				message.received_at.elapsed().as_secs()
+			);
+
+			let begin = SystemTime::now();
+
+			// TODO: Setting max rows * 2 to match extended matrix dimensions
+			let max_rows = header.extrinsics_root.rows * 2;
+			let max_cols = header.extrinsics_root.cols;
+			if max_cols < 3 {
+				error!(block_number, "chunk size less than 3");
+			}
+			let commitment = header.extrinsics_root.commitment.clone();
+
+			let cell_count = rpc::cell_count_for_confidence(cfg.confidence);
+			let positions = rpc::generate_random_cells(max_rows, max_cols, cell_count);
+			info!(block_number, "Random cells generated: {}", positions.len());
+
+			let (ipfs_fetched, unfetched) = fetch_cells_from_dht(
+				&ipfs,
+				block_number,
+				&positions,
+				cfg.max_parallel_fetch_tasks,
+			)
+			.await
+			.context("Failed to fetch cells from DHT")?;
+
+			info!(
+				block_number,
+				"Number of cells fetched from DHT: {}",
+				ipfs_fetched.len()
+			);
+			metrics.dht_fetched.set(ipfs_fetched.len() as f64);
+
+			let mut rpc_fetched = if cfg.disable_rpc {
+				vec![]
+			} else {
+				rpc::get_kate_proof(&rpc_url, block_number, unfetched)
+					.await
+					.context("Failed to fetch cells from node RPC")?
+			};
+
+			info!(
+				block_number,
+				"Number of cells fetched from RPC: {}",
+				rpc_fetched.len()
+			);
+			metrics.node_rpc_fetched.set(rpc_fetched.len() as f64);
+
+			let mut cells = vec![];
+			cells.extend(ipfs_fetched);
+			cells.extend(rpc_fetched.clone());
+
+			if positions.len() > cells.len() {
+				error!(
+					block_number,
+					"Failed to fetch {} cells",
+					positions.len() - cells.len()
+				);
+				continue;
+			}
+
+			let count = proof::verify_proof(
+				block_number,
+				max_rows,
+				max_cols,
+				&cells,
+				commitment.clone(),
+				pp.clone(),
+			);
+			info!(
+				block_number,
+				"Completed {count} verification rounds in \t{:?}",
+				begin.elapsed()?
+			);
+
+			// write confidence factor into on-disk database
+			store_confidence_in_db(db.clone(), block_number, count as u32)
+				.context("Failed to store confidence in DB")?;
+
+			let conf = calculate_confidence(count as u32);
+			info!(block_number, "Confidence factor: {}", conf);
+			metrics.block_confidence.set(conf);
+
+			// push latest mined block's header into column family specified
+			// for keeping block headers, to be used
+			// later for verifying IPFS stored data
+			//
+			// @note this same data store is also written to in
+			// another competing thread, which syncs all block headers
+			// in range [0, LATEST], where LATEST = latest block number
+			// when this process started
+			store_block_header_in_db(db.clone(), block_number, header)
+				.context("Failed to store block header in DB")?;
+
+			if let Some(partition) = &cfg.block_matrix_partition {
+				let positions = rpc::generate_partition_cells(partition, max_rows, max_cols);
+				info!(
+					block_number,
+					"Fetching partition ({}/{}) from RPC", partition.number, partition.fraction
+				);
+				for cells in positions.chunks(30) {
+					let partition_fetched =
+						rpc::get_kate_proof(&rpc_url, block_number, cells.to_vec())
+							.await
+							.context("Failed to fetch cells from node RPC")?;
+					let partition_fetched_filtered = partition_fetched
+						.into_iter()
+						.filter(|cell| {
+							!rpc_fetched
+								.iter()
+								.any(move |rpc_cell| rpc_cell.position.eq(&cell.position))
+						})
+						.collect::<Vec<_>>();
+					rpc_fetched.extend(partition_fetched_filtered.clone());
+				}
+			}
+
+			let rpc_fetched_len = rpc_fetched.len();
+			insert_into_dht(
+				&ipfs,
+				block_number,
+				rpc_fetched,
+				cfg.max_parallel_fetch_tasks,
+			)
+			.await;
+			info!(block_number, "{rpc_fetched_len} cells inserted into DHT");
+
+			// notify ipfs-based application client
+			// that newly mined block has been received
+			block_tx
+				.send(types::ClientMsg::from(message.params.header))
+				.context("Failed to send block message")?;
 		}
 	}
 	Ok(())
@@ -209,7 +271,7 @@ mod tests {
 	#[test]
 	fn test_cell_count_for_confidence() {
 		let count = 1;
-		assert_eq!(cell_count_for_confidence(60f64) > count, true);
+		assert!(cell_count_for_confidence(60f64) > count);
 		assert_eq!(
 			cell_count_for_confidence(100f64),
 			(-((1f64 - (99f64 / 100f64)).log2())).ceil() as u32
@@ -218,10 +280,9 @@ mod tests {
 			cell_count_for_confidence(49f64),
 			(-((1f64 - (99f64 / 100f64)).log2())).ceil() as u32
 		);
-		assert_eq!(
+		assert!(
 			(cell_count_for_confidence(99.99999999)) < 10
-				&& (cell_count_for_confidence(99.99999999)) > 0,
-			true
+				&& (cell_count_for_confidence(99.99999999)) > 0
 		);
 	}
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -238,7 +238,7 @@ pub async fn get_chain(url: &str) -> Result<String> {
 }
 
 //parsing the urls given in the vector of urls
-pub fn parse_urls(urls: Vec<String>) -> Result<Vec<url::Url>> {
+pub fn parse_urls(urls: &[String]) -> Result<Vec<url::Url>> {
 	urls.iter()
 		.map(|url| url::Url::parse(url))
 		.map(|r| r.map_err(|parse_error| anyhow!("Cannot parse URL: {}", parse_error)))
@@ -259,9 +259,9 @@ pub async fn check_connection(
 }
 
 //fn to check the rpc_url is secure or not and if it is working properly to return
-pub async fn check_http(full_node_rpc: Vec<String>) -> Result<String> {
+pub async fn check_http(full_node_rpc: &Vec<String>) -> Result<String> {
 	for rpc_url in full_node_rpc {
-		if (get_chain(&rpc_url).await).is_ok() {
+		if (get_chain(rpc_url).await).is_ok() {
 			return Ok(rpc_url.to_string());
 		}
 	}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -141,6 +141,25 @@ pub fn generate_random_cells(max_rows: u16, max_cols: u16, cell_count: u32) -> V
 	indices.into_iter().collect::<Vec<_>>()
 }
 
+pub fn generate_partition_cells(
+	partition: &Partition,
+	max_rows: u16,
+	max_cols: u16,
+) -> Vec<Position> {
+	let max_cells = (max_rows as u32) * (max_cols as u32);
+	let size = (max_cells as f64 / partition.fraction as f64).ceil() as u32;
+	let first_cell = size * (partition.number - 1) as u32;
+	let last_cell = size * (partition.number as u32);
+
+	(first_cell..last_cell)
+		.map(|cell| {
+			let col: u16 = cell as u16 / max_rows;
+			let row = cell as u16 % max_rows;
+			Position { row, col }
+		})
+		.collect::<Vec<_>>()
+}
+
 pub fn generate_kate_query_payload(block: u64, positions: &[Position]) -> String {
 	let query = positions
 		.iter()

--- a/src/types.rs
+++ b/src/types.rs
@@ -345,6 +345,7 @@ impl From<Option<u32>> for Mode {
 	}
 }
 
+/// Representation of a configuration used by this project.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuntimeConfig {
 	pub http_server_host: String,
@@ -360,7 +361,59 @@ pub struct RuntimeConfig {
 	pub avail_path: String,
 	pub log_level: String,
 	pub log_format_json: Option<bool>,
+	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT
+	pub disable_rpc: Option<bool>,
 	pub max_parallel_fetch_tasks: usize,
+}
+
+pub struct LightClientConfig {
+	pub full_node_ws: Vec<String>,
+	pub confidence: f64,
+	pub disable_rpc: bool,
+	pub max_parallel_fetch_tasks: usize,
+}
+
+impl From<&RuntimeConfig> for LightClientConfig {
+	fn from(val: &RuntimeConfig) -> Self {
+		LightClientConfig {
+			full_node_ws: val.full_node_ws.clone(),
+			confidence: val.confidence,
+			disable_rpc: val.disable_rpc == Some(true),
+			max_parallel_fetch_tasks: val.max_parallel_fetch_tasks,
+		}
+	}
+}
+
+pub struct SyncClientConfig {
+	pub confidence: f64,
+	pub disable_rpc: bool,
+	pub max_parallel_fetch_tasks: usize,
+}
+
+impl From<&RuntimeConfig> for SyncClientConfig {
+	fn from(val: &RuntimeConfig) -> Self {
+		SyncClientConfig {
+			confidence: val.confidence,
+			disable_rpc: val.disable_rpc == Some(true),
+			max_parallel_fetch_tasks: val.max_parallel_fetch_tasks,
+		}
+	}
+}
+
+pub struct AppClientConfig {
+	pub full_node_ws: Vec<String>,
+	pub disable_rpc: bool,
+	pub max_parallel_fetch_tasks: usize,
+}
+
+impl From<&RuntimeConfig> for AppClientConfig {
+	fn from(val: &RuntimeConfig) -> Self {
+		AppClientConfig {
+			full_node_ws: val.full_node_ws.clone(),
+			disable_rpc: val.disable_rpc == Some(true),
+			max_parallel_fetch_tasks: val.max_parallel_fetch_tasks,
+		}
+	}
 }
 
 impl Default for RuntimeConfig {
@@ -380,6 +433,7 @@ impl Default for RuntimeConfig {
 			avail_path: format!("avail_light_client_{}", 1),
 			log_level: "INFO".to_owned(),
 			log_format_json: Some(false),
+			disable_rpc: Some(false),
 			max_parallel_fetch_tasks: 8,
 		}
 	}


### PR DESCRIPTION
The intention to add this configuration parameter is to be able to test light clients which has disabled access to node RPC, which means they will rely only on DHT. That way, we will be able to test DHT performance, but prerequisite is to distribute whole matrix into DHT, and to wait enough for all data to be available in DHT. Former will be addressed in following PRs.