### PR TITLE
Ava block processing delay in blocks

### DIFF
--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -58,8 +58,18 @@ pub async fn run(
 					block_counter.inc();
 					let header = &params.header;
 
+					let blocks_delay = cfg.block_processing_blocks_delay.unwrap_or(0);
+					if blocks_delay as u64 > header.number {
+						info!("Skipping to delay block processing");
+						continue;
+					}
+
 					// now this is in `u64`
-					let block_number = header.number;
+					let block_number = header.number - blocks_delay as u64;
+					info!(
+						block_number,
+						"Latest block: {},  processing {}...", header.number, block_number
+					);
 
 					let begin = SystemTime::now();
 

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -18,23 +18,21 @@ use crate::{
 	},
 	http::calculate_confidence,
 	proof, rpc,
-	types::{self, ClientMsg},
+	types::{self, ClientMsg, LightClientConfig},
 };
 
 pub async fn run(
-	full_node_ws: Vec<String>,
-	confidence: f64,
+	cfg: LightClientConfig,
 	db: Arc<DB>,
 	ipfs: Ipfs<DefaultParams>,
 	rpc_url: String,
 	block_tx: SyncSender<ClientMsg>,
-	max_parallel_fetch_tasks: usize,
 	pp: PublicParameters,
 	registry: Registry,
 ) -> Result<()> {
 	info!("Starting light client...");
 	const BODY: &str = r#"{"id":1, "jsonrpc":"2.0", "method": "chain_subscribeFinalizedHeads"}"#;
-	let urls = rpc::parse_urls(full_node_ws)?;
+	let urls = rpc::parse_urls(&cfg.full_node_ws)?;
 	// Register metrics
 	let block_counter = Box::new(prometheus::Counter::new(
 		"block_number",
@@ -73,7 +71,7 @@ pub async fn run(
 					}
 					let commitment = header.extrinsics_root.commitment.clone();
 
-					let cell_count = rpc::cell_count_for_confidence(confidence);
+					let cell_count = rpc::cell_count_for_confidence(cfg.confidence);
 					let positions = rpc::generate_random_cells(max_rows, max_cols, cell_count);
 					info!(block_number, "Random cells generated: {}", positions.len());
 
@@ -81,7 +79,7 @@ pub async fn run(
 						&ipfs,
 						block_number,
 						&positions,
-						max_parallel_fetch_tasks,
+						cfg.max_parallel_fetch_tasks,
 					)
 					.await
 					.context("Failed to fetch cells from DHT")?;
@@ -92,9 +90,13 @@ pub async fn run(
 						ipfs_fetched.len()
 					);
 
-					let rpc_fetched = rpc::get_kate_proof(&rpc_url, block_number, unfetched)
-						.await
-						.context("Failed to fetch cells from node RPC")?;
+					let rpc_fetched = if cfg.disable_rpc {
+						vec![]
+					} else {
+						rpc::get_kate_proof(&rpc_url, block_number, unfetched)
+							.await
+							.context("Failed to fetch cells from node RPC")?
+					};
 
 					info!(
 						block_number,
@@ -147,8 +149,13 @@ pub async fn run(
 					store_block_header_in_db(db.clone(), block_number, header)
 						.context("Failed to store block header in DB")?;
 
-					insert_into_dht(&ipfs, block_number, rpc_fetched, max_parallel_fetch_tasks)
-						.await;
+					insert_into_dht(
+						&ipfs,
+						block_number,
+						rpc_fetched,
+						cfg.max_parallel_fetch_tasks,
+					)
+					.await;
 					info!(block_number, "Cells inserted into DHT");
 
 					// notify ipfs-based application client

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -238,7 +238,7 @@ pub async fn get_chain(url: &str) -> Result<String> {
 }
 
 //parsing the urls given in the vector of urls
-pub fn parse_urls(urls: Vec<String>) -> Result<Vec<url::Url>> {
+pub fn parse_urls(urls: &[String]) -> Result<Vec<url::Url>> {
 	urls.iter()
 		.map(|url| url::Url::parse(url))
 		.map(|r| r.map_err(|parse_error| anyhow!("Cannot parse URL: {}", parse_error)))
@@ -259,9 +259,9 @@ pub async fn check_connection(
 }
 
 //fn to check the rpc_url is secure or not and if it is working properly to return
-pub async fn check_http(full_node_rpc: Vec<String>) -> Result<String> {
+pub async fn check_http(full_node_rpc: &Vec<String>) -> Result<String> {
 	for rpc_url in full_node_rpc {
-		if (get_chain(&rpc_url).await).is_ok() {
+		if (get_chain(rpc_url).await).is_ok() {
 			return Ok(rpc_url.to_string());
 		}
 	}

--- a/src/types.rs
+++ b/src/types.rs
@@ -364,6 +364,8 @@ pub struct RuntimeConfig {
 	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT
 	pub disable_rpc: Option<bool>,
 	pub max_parallel_fetch_tasks: usize,
+	/// Number of blocks to postpone block processing after block finalized message arrives
+	pub block_processing_blocks_delay: Option<u8>,
 }
 
 pub struct LightClientConfig {
@@ -371,6 +373,7 @@ pub struct LightClientConfig {
 	pub confidence: f64,
 	pub disable_rpc: bool,
 	pub max_parallel_fetch_tasks: usize,
+	pub block_processing_blocks_delay: Option<u8>,
 }
 
 impl From<&RuntimeConfig> for LightClientConfig {
@@ -380,6 +383,7 @@ impl From<&RuntimeConfig> for LightClientConfig {
 			confidence: val.confidence,
 			disable_rpc: val.disable_rpc == Some(true),
 			max_parallel_fetch_tasks: val.max_parallel_fetch_tasks,
+			block_processing_blocks_delay: val.block_processing_blocks_delay,
 		}
 	}
 }
@@ -435,6 +439,7 @@ impl Default for RuntimeConfig {
 			log_format_json: Some(false),
 			disable_rpc: Some(false),
 			max_parallel_fetch_tasks: 8,
+			block_processing_blocks_delay: None,
 		}
 	}
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -345,6 +345,7 @@ impl From<Option<u32>> for Mode {
 	}
 }
 
+/// Representation of a configuration used by this project.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuntimeConfig {
 	pub http_server_host: String,
@@ -360,7 +361,59 @@ pub struct RuntimeConfig {
 	pub avail_path: String,
 	pub log_level: String,
 	pub log_format_json: Option<bool>,
+	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT
+	pub disable_rpc: Option<bool>,
 	pub max_parallel_fetch_tasks: usize,
+}
+
+pub struct LightClientConfig {
+	pub full_node_ws: Vec<String>,
+	pub confidence: f64,
+	pub disable_rpc: bool,
+	pub max_parallel_fetch_tasks: usize,
+}
+
+impl From<&RuntimeConfig> for LightClientConfig {
+	fn from(val: &RuntimeConfig) -> Self {
+		LightClientConfig {
+			full_node_ws: val.full_node_ws.clone(),
+			confidence: val.confidence,
+			disable_rpc: val.disable_rpc == Some(true),
+			max_parallel_fetch_tasks: val.max_parallel_fetch_tasks,
+		}
+	}
+}
+
+pub struct SyncClientConfig {
+	pub confidence: f64,
+	pub disable_rpc: bool,
+	pub max_parallel_fetch_tasks: usize,
+}
+
+impl From<&RuntimeConfig> for SyncClientConfig {
+	fn from(val: &RuntimeConfig) -> Self {
+		SyncClientConfig {
+			confidence: val.confidence,
+			disable_rpc: val.disable_rpc == Some(true),
+			max_parallel_fetch_tasks: val.max_parallel_fetch_tasks,
+		}
+	}
+}
+
+pub struct AppClientConfig {
+	pub full_node_ws: Vec<String>,
+	pub disable_rpc: bool,
+	pub max_parallel_fetch_tasks: usize,
+}
+
+impl From<&RuntimeConfig> for AppClientConfig {
+	fn from(val: &RuntimeConfig) -> Self {
+		AppClientConfig {
+			full_node_ws: val.full_node_ws.clone(),
+			disable_rpc: val.disable_rpc == Some(true),
+			max_parallel_fetch_tasks: val.max_parallel_fetch_tasks,
+		}
+	}
 }
 
 impl Default for RuntimeConfig {
@@ -380,6 +433,7 @@ impl Default for RuntimeConfig {
 			avail_path: format!("avail_light_client_{}", 1),
 			log_level: "INFO".to_owned(),
 			log_format_json: Some(false),
+			disable_rpc: Some(false),
 			max_parallel_fetch_tasks: 8,
 		}
 	}


### PR DESCRIPTION
Intention of this PR is to add delay to light client (and others consequently), which would give other light clients enough time to propagate whole matrix into DHT. This client should be used with RPC option set to disabled. This is simpler solution than previous one, and its working, but it some rought edges, like last n blocks would never be processed (if blockchain ever stops :D), and when LC reconnects, it will always process already processed blocks (e.g. last finalized is m, and LC will start from m - n).