### PR TITLE
Feature/ava fetch block partition

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -141,6 +141,25 @@ pub fn generate_random_cells(max_rows: u16, max_cols: u16, cell_count: u32) -> V
 	indices.into_iter().collect::<Vec<_>>()
 }
 
+pub fn generate_partition_cells(
+	partition: &Partition,
+	max_rows: u16,
+	max_cols: u16,
+) -> Vec<Position> {
+	let max_cells = (max_rows as u32) * (max_cols as u32);
+	let size = (max_cells as f64 / partition.fraction as f64).ceil() as u32;
+	let first_cell = size * (partition.number - 1) as u32;
+	let last_cell = size * (partition.number as u32);
+
+	(first_cell..last_cell)
+		.map(|cell| {
+			let col: u16 = cell as u16 / max_rows;
+			let row = cell as u16 % max_rows;
+			Position { row, col }
+		})
+		.collect::<Vec<_>>()
+}
+
 pub fn generate_kate_query_payload(block: u64, positions: &[Position]) -> String {
 	let query = positions
 		.iter()

--- a/src/types.rs
+++ b/src/types.rs
@@ -418,6 +418,7 @@ pub struct LightClientConfig {
 	pub disable_rpc: bool,
 	pub max_parallel_fetch_tasks: usize,
 	pub block_processing_delay: Option<u32>,
+	pub block_matrix_partition: Option<Partition>,
 }
 
 impl From<&RuntimeConfig> for LightClientConfig {
@@ -428,6 +429,7 @@ impl From<&RuntimeConfig> for LightClientConfig {
 			disable_rpc: val.disable_rpc == Some(true),
 			max_parallel_fetch_tasks: val.max_parallel_fetch_tasks,
 			block_processing_delay: val.block_processing_delay,
+			block_matrix_partition: val.block_matrix_partition.clone(),
 		}
 	}
 }


### PR DESCRIPTION
Intention of this PR is to enable configuration of partition of a block, which light client will download from RPC and publish into DHT. Partition specification is in format "{number}/{fraction}" (e.g. 6/20) where fraction is size of a part of a block, (1/20, 1/10 etc.) and number is number of a part in a block. Ceil rounding in calculation of which cells belongs to partition is used, to avoid missing cells. Tests needs to be added, since code is only POC. Fetching is implemented in simple manner, just fetch all cells from partition from RPC, remove already fetched and then store along with previously fetched into DHT. Please check if any further optimizations are needed.