### PR TITLE
Ava 291 additional ipfs metrics

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -401,6 +401,7 @@ pub struct RuntimeConfig {
 	pub avail_path: String,
 	pub log_level: String,
 	pub log_format_json: Option<bool>,
+	pub prometheus_port: Option<u16>,
 	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT
 	pub disable_rpc: Option<bool>,
 	pub max_parallel_fetch_tasks: usize,
@@ -483,6 +484,7 @@ impl Default for RuntimeConfig {
 			avail_path: format!("avail_light_client_{}", 1),
 			log_level: "INFO".to_owned(),
 			log_format_json: Some(false),
+			prometheus_port: Some(9520),
 			disable_rpc: Some(false),
 			max_parallel_fetch_tasks: 8,
 			block_processing_delay: None,


### PR DESCRIPTION
- enable ipfs_embed metrics to be exposed with other LC metrics
- total block number, as received from the header, has been separated from the number of blocks processed by the LC from (re)start