### PR TITLE
Sync cargo lock with 1.1.1 version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avail-light"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-std",


### PR DESCRIPTION
We missed commit of Cargo.lock changes after updating version in Cargo.toml to 1.1.1. This PR fixes the issue.