### PR TITLE
Added additional metrics

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -89,7 +89,7 @@ pub async fn insert_into_dht(
 	ttl: u64,
 ) -> f32 {
 	if cells.len() == 0 {
-		return 0.0;
+		return 1.0;
 	}
 
 	let cells: Vec<_> = cells.into_iter().map(DHTCell).collect::<Vec<_>>();

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -181,6 +181,7 @@ pub async fn run(
 				cells_fetched.len()
 			);
 			metrics.record(MetricEvent::DHTFetched(cells_fetched.len() as u64));
+			metrics.record(MetricEvent::DHTFetchedPercentage(cells_fetched.len() as f64 / positions.len() as f64));
 
 			let mut rpc_fetched = if cfg.disable_rpc {
 				vec![]

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -181,7 +181,9 @@ pub async fn run(
 				cells_fetched.len()
 			);
 			metrics.record(MetricEvent::DHTFetched(cells_fetched.len() as u64));
-			metrics.record(MetricEvent::DHTFetchedPercentage(cells_fetched.len() as f64 / positions.len() as f64));
+			metrics.record(MetricEvent::DHTFetchedPercentage(
+				cells_fetched.len() as f64 / positions.len() as f64,
+			));
 
 			let mut rpc_fetched = if cfg.disable_rpc {
 				vec![]

--- a/src/telemetry/metrics.rs
+++ b/src/telemetry/metrics.rs
@@ -10,6 +10,7 @@ pub struct Metrics {
 	session_block_counter: Counter,
 	total_block_number: Gauge,
 	dht_fetched: Gauge,
+	dht_fetched_percentage: Gauge<f64, AtomicU64>,
 	node_rpc_fetched: Gauge,
 	block_confidence: Gauge<f64, AtomicU64>,
 	rpc_call_duration: Gauge<f64, AtomicU64>,
@@ -21,6 +22,7 @@ pub enum MetricEvent {
 	SessionBlockCounter,
 	TotalBlockNumber(u32),
 	DHTFetched(u64),
+	DHTFetchedPercentage(f64),
 	NodeRPCFetched(u64),
 	BlockConfidence(f64),
 	RPCCallDuration(f64),
@@ -51,6 +53,13 @@ impl Metrics {
 			"dht_fetched",
 			"Number of cells fetched from DHT",
 			Box::new(dht_fetched.clone()),
+		);
+
+		let dht_fetched_percentage = Gauge::default();
+		sub_reg.register(
+			"dht_fetched_percentage",
+			"Percentage of cells fetched via DHT compared to total number of cells requested for random sampling",
+			Box::new(dht_fetched_percentage.clone()),
 		);
 
 		let node_rpc_fetched = Gauge::default();
@@ -92,6 +101,7 @@ impl Metrics {
 			session_block_counter,
 			total_block_number,
 			dht_fetched,
+			dht_fetched_percentage,
 			node_rpc_fetched,
 			block_confidence,
 			rpc_call_duration,
@@ -110,6 +120,9 @@ impl Metrics {
 			},
 			MetricEvent::DHTFetched(num) => {
 				self.dht_fetched.set(num);
+			},
+			MetricEvent::DHTFetchedPercentage(num) => {
+				self.dht_fetched_percentage.set(num);
 			},
 			MetricEvent::NodeRPCFetched(num) => {
 				self.node_rpc_fetched.set(num);

--- a/src/types.rs
+++ b/src/types.rs
@@ -337,11 +337,11 @@ mod port_range_format {
 }
 
 fn default_dht_parallelization_limit() -> usize {
-	800
+	20
 }
 
 fn default_query_proof_rpc_parallel_tasks() -> usize {
-	8
+	20
 }
 
 fn default_false() -> bool {
@@ -415,7 +415,7 @@ pub struct RuntimeConfig {
 	pub max_cells_per_rpc: Option<usize>,
 	/// Time-to-live for DHT entries in seconds (default: 3600).
 	pub ttl: Option<u64>,
-	/// Threshold for the number of cells fetched from DHT,
+	/// Threshold for the number of cells fetched via DHT for the app client
 	#[serde(default = "default_threshold")]
 	pub threshold: usize,
 }


### PR DESCRIPTION
- added a metric for DHT retrieval percentage compared to the entire number of cells requested for random sampling
- changed the default parameters for `dht_parallelization_limit` and `query_proof_rpc_parallel_tasks`, in light of the newest performance uplifts
- fixed an edge case for the `DHTPutSuccess` metric when invoking the function with 0 input cells