### PR TITLE
Add secret key import feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ log_level = "info"
 http_server_host = "127.0.0.1"
 # Light client HTTP server port (default: 7000).
 http_server_port = "7000"
-
-# Seed for Libp2p keypair. If not set, or seed is 0, random seed is generated
-libp2p_seed = 2
+# Secret key for libp2p keypair. Can be either set to `seed` or to `key`.
+# If set to seed, keypair will be generated from that seed.
+# If set to key, a valid ed25519 private key must be provided, else the client will fail
+# If `secret_key` is not set, random seed will be used.
+secret_key = { key =  "1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93" }
 # Libp2p service port range (port, range) (default: 37000).
 libp2p_port = "37000"
 # Vector of IPFS bootstrap nodes, used to bootstrap DHT. If not set, light client acts as a bootstrap node, waiting for first peer to connect for DHT bootstrap (default: empty).

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -30,7 +30,7 @@ use libp2p::{
 use tokio::sync::mpsc;
 use tracing::info;
 
-use crate::types::LibP2PConfig;
+use crate::types::{LibP2PConfig, SecretKey};
 
 use multihash::{self, Hasher};
 
@@ -41,18 +41,35 @@ pub fn init(
 	ttl: u64,
 ) -> Result<(Client, Arc<NetworkEvents>, EventLoop)> {
 	// Create a public/private key pair, either based on a seed or random
-	let id_keys = match cfg.libp2p_seed {
-		Some(seed) => {
-			let mut seed_digest = multihash::Sha3_256::digest(seed.as_bytes());
-			let bytes: &mut [u8] = seed_digest.as_mut();
-			let secret_key = ed25519::SecretKey::from_bytes(bytes)
-				.context("error generating secret key from seed")?;
-			identity::Keypair::Ed25519(secret_key.into())
+	let id_keys = match cfg.libp2p_secret_key {
+		// If seed is provided, generate secret key from seed
+		Some(seed) => match seed {
+			SecretKey::Seed { seed } => {
+				let mut seed_digest = multihash::Sha3_256::digest(seed.as_bytes());
+				let bytes: &mut [u8] = seed_digest.as_mut();
+				let secret_key = ed25519::SecretKey::from_bytes(bytes)
+					.context("error generating secret key from seed")?;
+				identity::Keypair::Ed25519(secret_key.into())
+			},
+			// Import secret key if provided
+			SecretKey::Key { key } => {
+				let mut decoded_key = [0u8; 32];
+				hex::decode_to_slice(key.into_bytes(), &mut decoded_key)
+					.context("error decoding secret key from config")?;
+				let secret_key = ed25519::SecretKey::from_bytes(decoded_key)
+					.context("error importing secret key")?;
+				identity::Keypair::Ed25519(secret_key.into())
+			},
 		},
+		// If neither seed nor secret key provided, generate secret key from random seed
 		None => identity::Keypair::generate_ed25519(),
 	};
 	let local_peer_id = PeerId::from(id_keys.public());
-	info!("Local peer id: {:?}", local_peer_id);
+	info!(
+		"Local peer id: {:?}. Public key: {:?}.",
+		local_peer_id,
+		id_keys.public()
+	);
 
 	// create transport
 	let transport = setup_transport(&id_keys, cfg.libp2p_tcp_port_reuse)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -352,7 +352,7 @@ pub struct RuntimeConfig {
 	#[serde(with = "port_range_format")]
 	pub http_server_port: (u16, u16),
 	/// Seed for Libp2p keypair. If not set, or seed is 0, random seed is generated
-	pub libp2p_seed: Option<u8>,
+	pub libp2p_seed: Option<String>,
 	/// Libp2p service port range (port, range) (default: 37000).
 	#[serde(default)]
 	#[serde(with = "port_range_format")]
@@ -492,7 +492,7 @@ impl From<&RuntimeConfig> for LightClientConfig {
 }
 
 pub struct LibP2PConfig {
-	pub libp2p_seed: Option<u8>,
+	pub libp2p_seed: Option<String>,
 	pub libp2p_port: (u16, u16),
 	pub libp2p_tcp_port_reuse: bool,
 	pub libp2p_autonat_only_global_ips: bool,
@@ -502,7 +502,7 @@ pub struct LibP2PConfig {
 impl From<&RuntimeConfig> for LibP2PConfig {
 	fn from(rtcfg: &RuntimeConfig) -> Self {
 		Self {
-			libp2p_seed: rtcfg.libp2p_seed,
+			libp2p_seed: rtcfg.libp2p_seed.clone(),
 			libp2p_port: rtcfg.libp2p_port,
 			libp2p_tcp_port_reuse: rtcfg.libp2p_tcp_port_reuse,
 			libp2p_autonat_only_global_ips: rtcfg.libp2p_autonat_only_global_ips,


### PR DESCRIPTION
- secret key can now be imported in hex format as a 32 bytes long hex string
- seed can now be of arbitrary length. SHA3-256 is used for initial (secure) hashing of the seed, providing us with the needed input size for ed25519 key pair generation