### PR TITLE
AV-120: Insert rows into dht

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,8 +2428,8 @@ dependencies = [
 
 [[package]]
 name = "kate-recovery"
-version = "0.7.1"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate-recovery/v0.7.1#d94ec5cb79aee3e6eb2c93235b44a08b7ce69450"
+version = "0.8.0"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate-recovery/v0.8.0#4c32cbeaf24abd7707a104b3f1e89679c0d7462e"
 dependencies = [
  "dusk-bytes",
  "dusk-plonk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Polygon Avail Team"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate-recovery/v0.7.1" }
+kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate-recovery/v0.8.0" }
 avail-subxt = { git = "https://github.com/maticnetwork/avail.git", tag = "v1.4.0-rc1" }
 subxt = "0.24.0"
 dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.12.0-polygon-2"  }

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,7 @@ async fn do_main() -> Result<()> {
 	let runtime_version = rpc::get_runtime_version(&rpc_client).await?;
 
 	info!("Reported version: {version}, runtime version: {runtime_version:?}");
-	if !version.starts_with("1.4.0")
+	if !version.starts_with("1.5.0")
 		|| runtime_version.spec_version != 7
 		|| runtime_version.spec_name != "data-avail"
 	{

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -145,7 +145,7 @@ async fn process_block(
 		.context("Failed to store confidence in DB")?;
 
 	network_client
-		.insert_into_dht(block_number, rpc_fetched)
+		.insert_cells_into_dht(block_number, rpc_fetched)
 		.await;
 	info!(block_number, "Cells inserted into DHT");
 	Ok(())

--- a/src/telemetry/metrics.rs
+++ b/src/telemetry/metrics.rs
@@ -16,6 +16,8 @@ pub struct Metrics {
 	rpc_call_duration: Gauge<f64, AtomicU64>,
 	dht_put_duration: Gauge<f64, AtomicU64>,
 	dht_put_success: Gauge<f64, AtomicU64>,
+	dht_put_rows_duration: Gauge<f64, AtomicU64>,
+	dht_put_rows_success: Gauge<f64, AtomicU64>,
 }
 
 pub enum MetricEvent {
@@ -28,6 +30,8 @@ pub enum MetricEvent {
 	RPCCallDuration(f64),
 	DHTPutDuration(f64),
 	DHTPutSuccess(f64),
+	DHTPutRowsDuration(f64),
+	DHTPutRowsSuccess(f64),
 }
 
 impl Metrics {
@@ -97,6 +101,20 @@ impl Metrics {
 			Box::new(dht_put_success.clone()),
 		);
 
+		let dht_put_rows_duration = Gauge::default();
+		sub_reg.register(
+			"dht_put_rows_duration",
+			"Time needed to perform DHT PUT rows operation for current block (in seconds)",
+			Box::new(dht_put_duration.clone()),
+		);
+
+		let dht_put_rows_success = Gauge::default();
+		sub_reg.register(
+			"dht_put_rows_sucess_rate",
+			"Success rate of the DHT PUT rows operation",
+			Box::new(dht_put_success.clone()),
+		);
+
 		Self {
 			session_block_counter,
 			total_block_number,
@@ -107,6 +125,8 @@ impl Metrics {
 			rpc_call_duration,
 			dht_put_duration,
 			dht_put_success,
+			dht_put_rows_duration,
+			dht_put_rows_success,
 		}
 	}
 
@@ -138,6 +158,12 @@ impl Metrics {
 			},
 			MetricEvent::DHTPutSuccess(num) => {
 				self.dht_put_success.set(num);
+			},
+			MetricEvent::DHTPutRowsDuration(num) => {
+				self.dht_put_rows_duration.set(num);
+			},
+			MetricEvent::DHTPutRowsSuccess(num) => {
+				self.dht_put_rows_success.set(num);
 			},
 		}
 	}


### PR DESCRIPTION
This PR adds rows insertion into DHT, with additional metrics for tracking rows insertion success rate and timings. Rows are inserted into DHT if client is configured with partition, after partition is fetched from DHT. Dependency to `avail-core` will be updated after tagging. 