### PR TITLE
Upgrade `avail-subxt` & `kate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,8 +390,8 @@ dependencies = [
 
 [[package]]
 name = "avail-subxt"
-version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail.git?tag=v1.3.0#3613e1007cfe6c015b3e3690ea11fc777ad11529"
+version = "0.2.0"
+source = "git+https://github.com/maticnetwork/avail.git?branch=AV-157-update-avail-subxt-and-lc#5a368491906d6ba85daa4cdb4cba4805a7880810"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2428,10 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "kate-recovery"
-version = "0.7.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.7.0#5782da6cd648da6bb3381713b8df12a8bd237e5c"
+version = "0.7.1"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=da-primitives/v0.4.2#d94ec5cb79aee3e6eb2c93235b44a08b7ce69450"
 dependencies = [
- "derive_more",
  "dusk-bytes",
  "dusk-plonk",
  "getrandom 0.2.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.7.1"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=da-primitives/v0.4.2#d94ec5cb79aee3e6eb2c93235b44a08b7ce69450"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate-recovery/v0.7.1#d94ec5cb79aee3e6eb2c93235b44a08b7ce69450"
 dependencies = [
  "dusk-bytes",
  "dusk-plonk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "avail-subxt"
 version = "0.2.0"
-source = "git+https://github.com/maticnetwork/avail.git?branch=AV-157-update-avail-subxt-and-lc#5a368491906d6ba85daa4cdb4cba4805a7880810"
+source = "git+https://github.com/maticnetwork/avail.git?tag=v1.4.0-rc1#498815d80c058b2a8988ecb0173bffbac8a035ec"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Polygon Avail Team"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "da-primitives/v0.4.2" }
+kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate-recovery/v0.7.1" }
 avail-subxt = { git = "https://github.com/maticnetwork/avail.git", tag = "v1.4.0-rc1" }
 subxt = "0.24.0"
 dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.12.0-polygon-2"  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["Polygon Avail Team"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.7.0" }
-avail-subxt = { git = "https://github.com/maticnetwork/avail.git", tag = "v1.3.0" }
+kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "da-primitives/v0.4.2" }
+avail-subxt = { git = "https://github.com/maticnetwork/avail.git", branch = "AV-157-update-avail-subxt-and-lc" }
 subxt = "0.24.0"
 dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.12.0-polygon-2"  }
 url = "2.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 authors = ["Polygon Avail Team"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Polygon Avail Team"]
 
 [dependencies]
 kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "da-primitives/v0.4.2" }
-avail-subxt = { git = "https://github.com/maticnetwork/avail.git", branch = "AV-157-update-avail-subxt-and-lc" }
+avail-subxt = { git = "https://github.com/maticnetwork/avail.git", tag = "v1.4.0-rc1" }
 subxt = "0.24.0"
 dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.12.0-polygon-2"  }
 url = "2.2.2"


### PR DESCRIPTION
- Upgrades `avail-subxt` & `kate` dependencies to use `data-avail v1.4.0-rc1`