### PR TITLE
Update cargo lock.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avail-light"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "async-std",


### PR DESCRIPTION
Latest main contains stale lock file, this PR fixes the issue.