### PR TITLE
Return decoded data on appdata endpoint.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "avail-subxt",
+ "base64 0.21.0",
  "chrono",
  "confy",
  "dusk-plonk",
@@ -444,6 +445,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "beef"
@@ -1881,7 +1888,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -2713,7 +2720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b8d02b9089241196479c6fdae22df4d4444509edb3a8e7ef388218ca9b5e3e"
 dependencies = [
  "asynchronous-codec",
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "fnv",
@@ -3102,7 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.13.1",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -4629,7 +4636,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -4638,7 +4645,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -5119,7 +5126,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "flate2",
  "futures",
@@ -6073,7 +6080,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -6101,8 +6108,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
- "rand 0.4.6",
+ "cfg-if 1.0.0",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ prometheus-client = "0.18.1"
 openssl = { version = "0.10", features = ["vendored"] }
 void = "1.0.2"
 itertools = "0.10.5"
+base64 = "0.21.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -183,17 +183,30 @@ Result:
 > `blockNumber << 32 | int32(confidence * 10 ** 7)`, where confidence is represented out of 10 ** 9.
 
 
-Given a block number (as _(hexa-)_ decimal number), return the content of the data if specified in config in hex string format
+Given a block number (as _(hexa-)_ decimal number), return the extrinsic in hex string format, if app id is specified in the config
 
 ```bash
-curl -s localhost:7000/v1/appdata/ <block-number>
+curl -s localhost:7000/v1/appdata/<block-number>
 ```
 
 Result:
 
 ```json
-{"block":386,"extrinsics":[{"app_id":1,"signature":{"Sr25519":"be86221cc07a461537570637d75a0569c2210286e85c693e3b31d94211b1ef1eaf451b13072066f745f70801ad6af0dcdf2e42b7bf77be2dc6709196b4d45889"},"data":"0x313537626233643536653339356537393237633664"}]}
+{"block":386,"extrinsics":["{hex_encoded_extrinsic}"]}
 ```
+
+Query parameter `decode=true` can be used to return submitted data in base64 encoded string:
+
+```bash
+curl -s localhost:7000/v1/appdata/<block-number>?decode=true
+```
+
+Result:
+
+```json
+{"block":386,"extrinsics":["{base64_encoded_submit_data}"]}
+```
+
 
 Returns the Mode of the Light Client
 


### PR DESCRIPTION
This PR adds `decode` boolean query parameter to `appdata` HTTP endpoint, to support retrieving decoded submitted data. 

If `decode` query parameter is missing or `false`, endpoint behaves same as before, preserving backward compatibility, and return hex string of encoded extrinsic. If `decode` is set to true, extrinsic is decoded and base64 string of submitted data is returned.

There was several options for specifying this behavior:
- config parameter: this is less flexible and it doesn't preserve compatibility if client is started with different setting
- different endpoint: since schema is same, but meaning of extrinsic field is same, same endpoint seems more natural
- specifying accept header: this allows for content negotiation but devs are less familiar with this kind of api
- query parameter: similar to accept header but more familiar
 
Base64 is chosen as most common encoding and easier use with online tools and in browser, but there could be more compact options which would require specific endpoint for each extrinsic, or some other solution.