### PR TITLE
Av 180

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ http_server_port = "7000"
 libp2p_seed = 1
 libp2p_port = "37000"
 
-full_node_rpc = ["http://127.0.0.1:9933"]
 full_node_ws = ["ws://127.0.0.1:9944"]
 app_id = 0
 confidence = 92.0
@@ -86,8 +85,6 @@ libp2p_port = "37000"
 # Vector of IPFS bootstrap nodes, used to bootstrap DHT. If not set, light client acts as a bootstrap node, waiting for first peer to connect for DHT bootstrap (default: empty).
 bootstraps = [["12D3KooWMm1c4pzeLPGkkCJMAgFbsfQ8xmVDusg272icWsaNHWzN", "/ip4/127.0.0.1/tcp/37000"]]
 
-# RPC endpoint of a full node for proof queries, etc. (default: http://127.0.0.1:9933).
-full_node_rpc = ["http://127.0.0.1:9933"]
 # WebSocket endpoint of a full node for subscribing to the latest header, etc (default: ws://127.0.0.1:9944).
 full_node_ws = ["ws://127.0.0.1:9944"]
 # ID of application used to start application client. If app_id is not set, or set to 0, application client is not started (default: 0).

--- a/src/http.rs
+++ b/src/http.rs
@@ -11,7 +11,7 @@
 use std::{
 	net::SocketAddr,
 	str::FromStr,
-	sync::{mpsc::SyncSender, Arc, Mutex},
+	sync::{Arc, Mutex},
 };
 
 use anyhow::{Context, Result};
@@ -28,7 +28,7 @@ use warp::{http::StatusCode, Filter};
 
 use crate::{
 	data::{get_confidence_from_db, get_decoded_data_from_db},
-	types::{CellContentQueryPayload, Mode, RuntimeConfig},
+	types::{Mode, RuntimeConfig},
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -244,12 +244,7 @@ struct AppDataQuery {
 }
 
 /// Runs HTTP server
-pub async fn run_server(
-	store: Arc<DB>,
-	cfg: RuntimeConfig,
-	_cell_query_tx: SyncSender<CellContentQueryPayload>,
-	counter: Arc<Mutex<u32>>,
-) {
+pub async fn run_server(store: Arc<DB>, cfg: RuntimeConfig, counter: Arc<Mutex<u32>>) {
 	let host = cfg.http_server_host.clone();
 	let port = if cfg.http_server_port.1 > 0 {
 		let port: u16 = thread_rng().gen_range(cfg.http_server_port.0..=cfg.http_server_port.1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,22 +135,9 @@ async fn do_main() -> Result<()> {
 
 	let db = init_db(&cfg.avail_path).context("Failed to init DB")?;
 
-	// Have access to key value data store, now this can be safely used
-	// from multiple threads of execution
-
-	// This channel will be used for message based communication between
-	// two tasks
-	// task_0: HTTP request handler ( query sender )
-	// task_1: DHT client ( query receiver & hopefully successfully resolver )
-	let (cell_query_tx, _) = sync_channel::<crate::types::CellContentQueryPayload>(1 << 4);
 	// this spawns tokio task which runs one http server for handling RPC
 	let counter = Arc::new(Mutex::new(0u32));
-	tokio::task::spawn(http::run_server(
-		db.clone(),
-		cfg.clone(),
-		cell_query_tx,
-		counter.clone(),
-	));
+	tokio::task::spawn(http::run_server(db.clone(), cfg.clone(), counter.clone()));
 
 	let (network_client, network_event_loop) = network::init(
 		(&cfg).into(),

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -1,0 +1,39 @@
+use std::{sync::mpsc::SyncSender, time::Instant};
+
+use anyhow::{anyhow, Context};
+use avail_subxt::{primitives::Header, AvailConfig};
+use subxt::OnlineClient;
+use tracing::{error, info};
+
+pub async fn finalized_headers(
+	rpc_client: OnlineClient<AvailConfig>,
+	message_tx: SyncSender<(Header, Instant)>,
+	error_sender: SyncSender<anyhow::Error>,
+) {
+	match rpc_client.rpc().subscribe_finalized_blocks().await {
+		Ok(mut new_heads_sub) => {
+			while let Some(message) = new_heads_sub.next().await {
+				let received_at = Instant::now();
+				if let Err(error) = message
+					.context("Failed to read web socket message")
+					.and_then(|header| {
+						info!(header.number, "Received finalized block header");
+						let message = (header, received_at);
+						message_tx.send(message).context("Send failed")
+					}) {
+					error!("Fail to process finalized block header: {error}");
+				}
+			}
+			let error = anyhow!("Finalized blocks subscription disconnected");
+			if let Err(error) = error_sender.send(error) {
+				error!("Cannot send error to error channel: {error}");
+			}
+		},
+		Err(error) => {
+			error!("Failed to subscribe to finalized blocks: {error}");
+			if let Err(error) = error_sender.send(error.into()) {
+				error!("Cannot send error to error channel: {error}");
+			}
+		},
+	}
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -200,8 +200,6 @@ pub struct RuntimeConfig {
 	/// Libp2p service port range (port, range) (default: 37000).
 	#[serde(with = "port_range_format")]
 	pub libp2p_port: (u16, u16),
-	/// RPC endpoint of a full node for proof queries, etc. (default: http://127.0.0.1:9933).
-	pub full_node_rpc: Vec<String>,
 	/// Configures LibP2P TCP port reuse for local sockets, which implies reuse of listening ports for outgoing connections to enhance NAT traversal capabilities (default: false)
 	pub libp2p_tcp_port_reuse: bool,
 	/// Configures LibP2P AutoNAT behaviour to reject probes as a server for clients that are observed at a non-global ip address (default: false)
@@ -431,7 +429,6 @@ impl Default for RuntimeConfig {
 			secret_key: None,
 			libp2p_tcp_port_reuse: false,
 			libp2p_autonat_only_global_ips: false,
-			full_node_rpc: vec!["http://127.0.0.1:9933".to_owned()],
 			full_node_ws: vec!["ws://127.0.0.1:9944".to_owned()],
 			app_id: None,
 			confidence: 92.0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -465,21 +465,6 @@ impl Default for RuntimeConfig {
 	}
 }
 
-/// This structure is used for encapsulating all things required for
-/// querying IPFS client for cell content
-/// A specific block number is required
-/// In that block row and column numbers are required
-/// Finally one channel is also passed which will be used
-/// by this message receiver to respond back as an attempt to
-/// resolve query
-#[derive(Clone)]
-pub struct CellContentQueryPayload {
-	pub block: u32,
-	pub row: u16,
-	pub col: u16,
-	pub res_chan: std::sync::mpsc::SyncSender<Option<Vec<u8>>>,
-}
-
 #[cfg(test)]
 mod tests {
 	use super::delay_for;


### PR DESCRIPTION
This PR moves light client into separate tokio task, and introduces error channel on which main thread is block, and which is used to signal that application should exit with error. To avoid sending at closed channel, senders should exit its own thread after terminating condition occurs. Channel is sync and bounded which means that other senders will be blocked in case if two or more errors are sent at same time. This PR also removes obsolete structs and configuration.